### PR TITLE
Conditionally encode the response for Python 3.2 and Python 3.3 to work properly

### DIFF
--- a/httmock.py
+++ b/httmock.py
@@ -27,7 +27,10 @@ def response(status_code=200, content='', headers=None, reason=None, elapsed=0,
     res = requests.Response()
     res.status_code = status_code
     if isinstance(content, dict):
-        content = json.dumps(content)
+        try:
+            content = bytes(json.dumps(content), 'utf-8')
+        except TypeError:
+            content = json.dumps(content)
     res._content = content
     res.headers = structures.CaseInsensitiveDict(headers or {})
     res.reason = reason


### PR DESCRIPTION
Without the encoding, requests will bomb out in Python 3 with:

```
Traceback (most recent call last):
    self.assertEqual(self.content, response.json())
  File "/home/travis/virtualenv/python3.2/lib/python3.2/site-packages/requests/models.py", line 687, in json
    encoding = guess_json_utf(self.content)
  File "/home/travis/virtualenv/python3.2/lib/python3.2/site-packages/requests/utils.py", line 518, in guess_json_utf
    nullcount = sample.count(_null)
TypeError: Can't convert 'bytes' object to str implicitly
```
