### PR TITLE
Python 3 JSON dump encoding test

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -161,6 +161,28 @@ class ResponseTest(unittest.TestCase):
         self.assertEqual(r.cookies['foo'], 'bar')
 
 
+class Python3EncodingTest(unittest.TestCase):
+    """Previous behavior would result in this test failing in Python3 with:
+
+    TypeError: Can't convert 'bytes' object to str implicitly
+
+    """
+    def setUp(self):
+        self.content = {'name': 'foo', 'ipv4addr': '127.0.0.1'}
+
+    @all_requests
+    def get_mock(self, url, request):
+        return {'content': self.content,
+                'headers': {'content-type': 'application/json'},
+                'status_code': 200,
+                'elapsed': 5}
+
+    def test_get(self):
+        with HTTMock(self.get_mock):
+            response = requests.get('http://foo_bar')
+            self.assertEqual(self.content, response.json())
+
+
 suite = unittest.TestSuite()
 loader = unittest.TestLoader()
 suite.addTests(loader.loadTestsFromTestCase(MockTest))
@@ -169,3 +191,4 @@ suite.addTests(loader.loadTestsFromTestCase(AllRequestsDecoratorTest))
 suite.addTests(loader.loadTestsFromTestCase(AllRequestsMethodDecoratorTest))
 suite.addTests(loader.loadTestsFromTestCase(UrlMatchMethodDecoratorTest))
 suite.addTests(loader.loadTestsFromTestCase(ResponseTest))
+suite.addTests(loader.loadTestsFromTestCase(Python3EncodingTest))


### PR DESCRIPTION
If relying on the response content auto-serialization of dict to JSON, Python 3 evaluations of the response content fail with a type error due to how requests.utils.guess_json_utf() attempts to figure out if the content is UTF-8 or not.

This commit adds a unit test that fails when using this functionality, causing TypeError exception:

```
======================================================================
ERROR: test_get (tests.Python3EncodingTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/gmr/Dropbox/Source/httmock/tests.py", line 183, in test_get
    self.assertEqual(self.content, response.json())
  File "/usr/local/Cellar/python3/3.3.2/Frameworks/Python.framework/Versions/3.3/lib/python3.3/site-packages/requests/models.py", line 687, in json
    encoding = guess_json_utf(self.content)
  File "/usr/local/Cellar/python3/3.3.2/Frameworks/Python.framework/Versions/3.3/lib/python3.3/site-packages/requests/utils.py", line 518, in guess_json_utf
    nullcount = sample.count(_null)
TypeError: Can't convert 'bytes' object to str implicitly
```
