### PR TITLE
Allow real requests if return value from intercept is not a Response object

### DIFF
--- a/httmock.py
+++ b/httmock.py
@@ -111,7 +111,11 @@ class HTTMock(object):
                             request)
         elif isinstance(res, basestring):
             return response(content=res)
-        return None
+        elif res is None:
+            return None
+        else:
+            raise TypeError(
+                "Dont know how to handle response of type {}".format(type(res)))
 
 
 def with_httmock(*handlers):

--- a/tests.py
+++ b/tests.py
@@ -72,6 +72,13 @@ class MockTest(unittest.TestCase):
             r = requests.get('http://example.com/')
         self.assertEqual(r.status_code, 200)
 
+    def test_invalid_intercept_response_raises_value_error(self):
+        @all_requests
+        def response_content(url, request):
+            return -1
+        with HTTMock(response_content):
+            self.assertRaises(TypeError, requests.get, 'http://example.com/')
+
 
 class DecoratorTest(unittest.TestCase):
 


### PR DESCRIPTION
Seems like the _real_session_send will never be reached since intercept always returns a valid Response object. Our use-case is that we want to be able to run the same test against the actual target server in which case we just modify the net-loc.
