### PR TITLE
Give the response some context, just like requests does.

### DIFF
--- a/httmock.py
+++ b/httmock.py
@@ -39,6 +39,10 @@ def response(status_code=200, content='', headers=None, reason=None, elapsed=0,
     res.headers = structures.CaseInsensitiveDict(headers or {})
     res.reason = reason
     res.elapsed = datetime.timedelta(elapsed)
+    res.request = request
+    res.url = request.url
+    if isinstance(request.url, bytes):
+        res.url = request.url.decode('utf-8')
     if 'set-cookie' in res.headers:
         res.cookies.extract_cookies(cookies.MockResponse(Headers(res)),
                                     cookies.MockRequest(request))


### PR DESCRIPTION
See https://github.com/kennethreitz/requests/blob/master/requests/adapters.py#L180-L189.

I'm using httmock to test a new API wrapper and checking the internals of the `request` object to ensure that my wrapper is setting up the calls correctly. In https://github.com/kennethreitz/requests/blob/master/requests/adapters.py#L180-L189 , `requests` adds both the `request` and `request.url` as attributes on the response. This does the same.
