### PR TITLE
make urlmatch optionally filter based on request method

### DIFF
--- a/httmock.py
+++ b/httmock.py
@@ -69,14 +69,13 @@ def urlmatch(scheme=None, netloc=None, path=None, method=None):
         def inner(self_or_url, url_or_request, *args, **kwargs):
             if isinstance(self_or_url, urlparse.SplitResult):
                 url = self_or_url
-                re = url_or_request
+                request = url_or_request
             else:
                 url = url_or_request
-                re = args[0]
-
-            if isinstance(re, requests.PreparedRequest) and method is not None and method.lower() != re.method.lower():
+                request = args[0]
+            if isinstance(request, requests.PreparedRequest) and method is not None and \
+                            method.lower() != request.method.lower():
                 return
-
             if scheme is not None and scheme != url.scheme:
                 return
             if netloc is not None and not re.match(netloc, url.netloc):


### PR DESCRIPTION
More REST compliant services have the same URL for different operations and the difference between them is the HTTP method.
This change allows multiple functions to mock the same URL but for different HTTP methods i.e. GET vs POST can be mocked separately for the same URL.

It maintains previous behaviour so if a function doesn't specify the method param and multiple functions match the same URL the first one to return a value that's not None is taken. 
