### PR TITLE
setup.py: Require requests >= 1.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
         'Intended Audience :: Developers',
         'Topic :: Software Development :: Testing',
         'Operating System :: OS Independent'],
-    install_requires=['requests'],
+    install_requires=['requests >= 1.0.0'],
     license=LICENSE,
     long_description=DESCRIPTION,
     test_suite='tests')


### PR DESCRIPTION
httmock will not work with very old versions of requests, such as the
0.14.2 which is shipping with Debian squeeze
