### PR TITLE
Add support for response.raw attribute.

### DIFF
--- a/httmock.py
+++ b/httmock.py
@@ -10,6 +10,10 @@ try:
     import urlparse
 except ImportError:
     import urllib.parse as urlparse
+try:
+    from cStringIO import StringIO
+except ImportError:
+    from io import StringIO
 
 if sys.version_info >= (3, 0, 0):
     basestring = str
@@ -27,7 +31,7 @@ class Headers(object):
 
 
 def response(status_code=200, content='', headers=None, reason=None, elapsed=0,
-             request=None):
+             request=None, stream=False):
     res = requests.Response()
     res.status_code = status_code
     if isinstance(content, dict):
@@ -41,6 +45,10 @@ def response(status_code=200, content='', headers=None, reason=None, elapsed=0,
     res.reason = reason
     res.elapsed = datetime.timedelta(elapsed)
     res.request = request
+    if stream:
+        res.raw = StringIO(content if content is not None else '')
+    else:
+        res.raw = StringIO('')
     if hasattr(request, 'url'):
         res.url = request.url
         if isinstance(request.url, bytes):
@@ -106,7 +114,7 @@ class HTTMock(object):
         self._real_session_send = requests.Session.send
 
         def _fake_send(session, request, **kwargs):
-            response = self.intercept(request)
+            response = self.intercept(request, stream=kwargs['stream'])
             if isinstance(response, requests.Response):
                 # this is pasted from requests to handle redirects properly:
                 kwargs.setdefault('stream', session.stream)
@@ -145,7 +153,7 @@ class HTTMock(object):
     def __exit__(self, exc_type, exc_val, exc_tb):
         requests.Session.send = self._real_session_send
 
-    def intercept(self, request):
+    def intercept(self, request, stream):
         url = urlparse.urlsplit(request.url)
         res = first_of(self.handlers, url, request)
         if isinstance(res, requests.Response):
@@ -156,9 +164,10 @@ class HTTMock(object):
                             res.get('headers'),
                             res.get('reason'),
                             res.get('elapsed', 0),
-                            request)
+                            request,
+                            stream=stream)
         elif isinstance(res, basestring):
-            return response(content=res)
+            return response(content=res, stream=stream)
         elif res is None:
             return None
         else:

--- a/tests.py
+++ b/tests.py
@@ -63,6 +63,11 @@ class MockTest(unittest.TestCase):
             r = requests.get('http://example.com/')
         self.assertEqual(r.content, 'Hello from example.com')
 
+    def test_stream(self):
+        with HTTMock(any_mock):
+            r = requests.get('http://example.com/', stream=True)
+        self.assertEqual(r.raw.read(), 'Hello from example.com')
+
     def test_netloc_fallback(self):
         with HTTMock(google_mock, facebook_mock):
             r = requests.get('http://google.com/')
@@ -187,6 +192,14 @@ class ResponseTest(unittest.TestCase):
         r = response(200, None, {'Content-Type': 'application/json'})
         self.assertEqual(r.headers['content-type'], 'application/json')
 
+    def test_response_stream_raw(self):
+        r = response(200, 'content', {'Content-Type': 'application/json'}, stream=True)
+        self.assertEqual(r.raw.read(), 'content')
+
+    def test_response_nostream_raw(self):
+        r = response(200, 'content', {'Content-Type': 'application/json'})
+        self.assertEqual(r.raw.read(), '')
+
     def test_response_cookies(self):
         @all_requests
         def response_content(url, request):
@@ -224,3 +237,4 @@ class ResponseTest(unittest.TestCase):
             response = requests.get('http://example.com/')
             self.assertEqual(len(response.history), 1)
             self.assertEqual(response.content, 'Hello from Google')
+


### PR DESCRIPTION
Response objects in requests are documented to contain a `raw` attribute that is a file-like object.  When the request is made with `stream=True`, the `raw` attribute can be read to stream in the content.  Otherwise, the `raw` attribute looks like a file-like object with no bytes left to read.

This PR adds support for the raw attribute and its behavior (at least how requests behaves currently).
