### PR TITLE
Store cookies in session

### DIFF
--- a/httmock.py
+++ b/httmock.py
@@ -136,6 +136,9 @@ class HTTMock(object):
                     history.insert(0, response)
                     response = history.pop()
                     response.history = tuple(history)
+                    for resp in history:
+                        session.cookies.update(resp.cookies)
+                session.cookies.update(response.cookies)
                 return response
 
             return self._real_session_send(session, request, **kwargs)

--- a/tests.py
+++ b/tests.py
@@ -198,6 +198,39 @@ class ResponseTest(unittest.TestCase):
         self.assertTrue('foo' in r.cookies)
         self.assertEqual(r.cookies['foo'], 'bar')
 
+    def test_response_cookies_stored_in_session(self):
+        cookies = 'foo=bar;'
+
+        @all_requests
+        def response_content(url, request):
+            return response(200, 'Foo', {'Set-Cookie': cookies},
+                            request=request)
+
+        session = requests.Session()
+        with HTTMock(response_content):
+            r = session.get('https://foo_bar')
+            self.assertEqual(r.cookies['foo'], 'bar')
+            self.assertEqual(session.cookies['foo'], 'bar')
+            cookies = 'baz=qux;'
+            r = session.get('https://foo_bar')
+            self.assertTrue('foo' not in r.cookies)
+            self.assertEqual(session.cookies['foo'], 'bar')
+            self.assertEqual(session.cookies['baz'], 'qux')
+
+    def test_session_cookies_with_redirect(self):
+        @urlmatch(netloc='example.com')
+        def get_mock(url, request):
+            return {'status_code': 302,
+                    'headers': {'Location': 'http://google.com/',
+                                'Set-Cookie': 'foo=bar;'}}
+
+        session = requests.Session()
+        with HTTMock(get_mock, google_mock):
+            r = session.get('http://example.com/')
+            self.assertEqual(len(r.history), 1)
+            self.assertTrue("foo" not in r.cookies)
+            self.assertTrue("foo" in session.cookies)
+
     def test_python_version_encoding_differences(self):
         # Previous behavior would result in this test failing in Python3 due
         # to how requests checks for utf-8 JSON content in requests.utils with:


### PR DESCRIPTION
Requests do this using  `extract_cookies_to_jar(self.cookies, request, r.raw)`
[requests/sessions.py#L583-L589](https://github.com/kennethreitz/requests/blob/2fc6e8a894a5378dd16b2653df9ccf875d0bddf8/requests/sessions.py#L583-L589)
But `raw` is always `None` now #23.  Anyway, `cookies.update(...)` works fine.
