### PR TITLE
Allow content to also be a bytes

### DIFF
--- a/httmock.py
+++ b/httmock.py
@@ -173,7 +173,7 @@ class HTTMock(object):
                             res.get('reason'),
                             res.get('elapsed', 0),
                             request)
-        elif isinstance(res, basestring):
+        elif isinstance(res, (basestring, bytes)):
             return response(content=res)
         elif res is None:
             return None


### PR DESCRIPTION
As mentioned [here](http://docs.python-requests.org/en/latest/user/quickstart/#binary-response-content), `content` should be a bytes, not normal string. If I return plain string:-

```
@urlmatch(path='(.*)?/messages/send/')
        def message_send(url, request):
             return '{"status": "OK"}'
```
Trying to do `r.json()` will give error:-

```
File "/home/kamal/msg/trunk/eggs/requests-2.7.0-py3.4.egg/requests/models.py", line 809, in json
    encoding = guess_json_utf(self.content)
  File "/home/kamal/msg/trunk/eggs/requests-2.7.0-py3.4.egg/requests/utils.py", line 631, in guess_json_utf
    nullcount = sample.count(_null)
TypeError: Can't convert 'bytes' object to str implicitly
```

So I have to return encoded string:-
```
@urlmatch(path='(.*)?/messages/send/')
        def message_send(url, request):
             return '{"status": "OK"}'.encode('utf8')
```

But `intercept()` function only accept `basestring`.