### PR TITLE
Added decorator for remembering call count

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ python:
     - 2.6
     - 2.7
     - pypy
-    - 3.2
     - 3.3
     - 3.4
+    - 3.5
 install:
     - "pip install requests"
 script: nosetests

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,5 @@ python:
     - 3.3
     - 3.4
 install:
-    - "pip install requests --use-mirrors"
+    - "pip install requests"
 script: nosetests

--- a/tests.py
+++ b/tests.py
@@ -134,7 +134,7 @@ class AllRequestsDecoratorTest(unittest.TestCase):
         def response_content(url, request):
             return {'status_code': 200, 'content': 'Oh hai'}
         with HTTMock(response_content):
-            r = requests.get('https://foo_bar')
+            r = requests.get('https://example.com/')
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.content, b'Oh hai')
 
@@ -143,7 +143,7 @@ class AllRequestsDecoratorTest(unittest.TestCase):
         def response_content(url, request):
             return 'Hello'
         with HTTMock(response_content):
-            r = requests.get('https://foo_bar')
+            r = requests.get('https://example.com/')
         self.assertEqual(r.content, b'Hello')
 
 
@@ -154,7 +154,7 @@ class AllRequestsMethodDecoratorTest(unittest.TestCase):
 
     def test_all_requests_response(self):
         with HTTMock(self.response_content):
-            r = requests.get('https://foo_bar')
+            r = requests.get('https://example.com/')
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.content, b'Oh hai')
 
@@ -164,7 +164,7 @@ class AllRequestsMethodDecoratorTest(unittest.TestCase):
 
     def test_all_str_response(self):
         with HTTMock(self.string_response_content):
-            r = requests.get('https://foo_bar')
+            r = requests.get('https://example.com/')
         self.assertEqual(r.content, b'Hello')
 
 
@@ -224,7 +224,7 @@ class ResponseTest(unittest.TestCase):
             return response(200, 'Foo', {'Set-Cookie': 'foo=bar;'},
                             request=request)
         with HTTMock(response_content):
-            r = requests.get('https://foo_bar')
+            r = requests.get('https://example.com/')
         self.assertEqual(len(r.cookies), 1)
         self.assertTrue('foo' in r.cookies)
         self.assertEqual(r.cookies['foo'], 'bar')
@@ -242,7 +242,7 @@ class ResponseTest(unittest.TestCase):
                     'elapsed': 5}
 
         with HTTMock(get_mock):
-            response = requests.get('http://foo_bar')
+            response = requests.get('http://example.com/')
             self.assertEqual(self.content, response.json())
 
     def test_mock_redirect(self):


### PR DESCRIPTION
What's new:
* Introduced decorator `remember_called` for store various metadata about handler call. For now it's just `called` and `count` fields. It may be helpful when testing method with different requests or with request retries.

Fixes:
* Several fixes in CI: removed deprecated pip option and updated python versions
* IDNA-compatible hostnames usage in unit tests

Example:

``` python

import httmock
import requests

@httmock.urlmatch(path=r".*login")
@httmock.remember_called
def login_request(url, request):
    return {"token": "some_secret_token"}

@httmock.urlmatch(path=r".*test")
@httmock.remember_called
def test_request(url, requests):
    return {"response": "test"}


class Client(object):
    def __init__(self):
        self.token = None

    def login(self):
        self.token = requests.get("api/login")["token"]

    def send_request(self, method, url):
        if not self.token:
            self.login()
        return requests.request(method, url).json()

def test_send_request():
    with httmock.HTTMock(login_payload, test_request):
        Client().send_request("get", "api/test")

    assert login_request.call["called"]
    assert login_request.call["count"] == 1
    assert self.token

    assert test_request.call["called"]

def test_send_request_without():
    client = Client()
    client.token = "some_secret_token"

    with httmock.HTTMock(login_payload, test_request):
        client.send_request("get", "api/test")

    assert not login_request.call["called"]
    assert test_request.call["called"]
```
