### PR TITLE
Set response.encoding to the charset from the Content-Type header.

### DIFF
--- a/httmock.py
+++ b/httmock.py
@@ -4,7 +4,7 @@ from requests import cookies
 import json
 import re
 import requests
-from requests import structures
+from requests import structures, utils
 import sys
 try:
     import urlparse
@@ -49,6 +49,7 @@ def response(status_code=200, content='', headers=None, reason=None, elapsed=0,
     res._content = content
     res._content_consumed = content
     res.headers = structures.CaseInsensitiveDict(headers or {})
+    res.encoding = utils.get_encoding_from_headers(res.headers)
     res.reason = reason
     res.elapsed = datetime.timedelta(elapsed)
     res.request = request

--- a/tests.py
+++ b/tests.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import requests
 import unittest
 
@@ -40,6 +42,17 @@ def facebook_mock(url, request):
 @remember_called
 def facebook_mock_count(url, request):
     return 'Hello from Facebook'
+
+
+@all_requests
+def charset_utf8(url, request):
+    return {
+        'content': u'Motörhead'.encode('utf-8'),
+        'status_code': 200,
+        'headers': {
+            'Content-Type': 'text/plain; charset=utf-8'
+        }
+    }
 
 
 def any_mock(url, request):
@@ -111,6 +124,13 @@ class MockTest(unittest.TestCase):
             return -1
         with HTTMock(response_content):
             self.assertRaises(TypeError, requests.get, 'http://example.com/')
+
+    def test_encoding_from_contenttype(self):
+        with HTTMock(charset_utf8):
+            r = requests.get('http://example.com/')
+        self.assertEqual(r.encoding, 'utf-8')
+        self.assertEqual(r.text, u'Motörhead')
+        self.assertEqual(r.content, r.text.encode('utf-8'))
 
 
 class DecoratorTest(unittest.TestCase):


### PR DESCRIPTION
Emulate the behaviour of the unmocked Requests library, where the
'encoding' attribute of Response objects is set to the charset specified
in the Content-Type header.  Without this, response.text may in certain
situations get decoded to Unicode using the wrong encoding.