### PR TITLE
Added a request list to remember_called decorator

### DIFF
--- a/httmock.py
+++ b/httmock.py
@@ -107,7 +107,8 @@ def urlmatch(scheme=None, netloc=None, path=None, method=None, query=None):
 def handler_init_call(handler):
     setattr(handler, 'call', {
         'count': 0,
-        'called': False
+        'called': False,
+        'requests': []
     })
 
 
@@ -115,7 +116,8 @@ def handler_clean_call(handler):
     if hasattr(handler, 'call'):
         handler.call.update({
             'count': 0,
-            'called': False
+            'called': False,
+            'requests': []
         })
 
 
@@ -125,7 +127,7 @@ def handler_called(handler, *args, **kwargs):
     finally:
         handler.call['count'] += 1
         handler.call['called'] = True
-
+        handler.call['requests'].append(args[1])
 
 def remember_called(func):
     handler_init_call(func)

--- a/tests.py
+++ b/tests.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 import requests
 import unittest
 
@@ -42,6 +41,11 @@ def facebook_mock(url, request):
 @remember_called
 def facebook_mock_count(url, request):
     return 'Hello from Facebook'
+
+@urlmatch(netloc=r'(.*\.)?google\.com$', path=r'^/$', method='POST')
+@remember_called
+def google_mock_store_requests(url, request):
+    return 'Posting at Google'
 
 
 @all_requests
@@ -354,3 +358,13 @@ class RememberCalledTest(unittest.TestCase):
 
         self.several_calls(1, requests.get, 'http://facebook.com/')
         self.assertEquals(facebook_mock_count.call['count'], 4)
+
+    def test_store_several_requests(self):
+        with HTTMock(google_mock_store_requests):
+            payload = {"query": "foo"}
+            requests.post('http://google.com', data=payload)
+
+        self.assertTrue(google_mock_store_requests.call['called'])
+        self.assertEqual(google_mock_store_requests.call['count'], 1)
+        request = google_mock_store_requests.call['requests'][0]
+        self.assertEqual(request.body, 'query=foo')


### PR DESCRIPTION
I need to assert the payload sent to an external host, so I added the request list in order to ensure my data was properly formed.

The scenario it's a functional tests with no integration servers. I need to test a call to an api, although it's my code I consider it as a blackbox. this blackbox must to do a call to another api so I have not direct way to validate the third call. Using the request history I can validate the call. Something like this:

    def test_store_several_requests(self):
        with HTTMock(google_mock_store_requests):
            payload = {"query": "foo"}
            requests.post('http://google.com', data=payload)

        self.assertTrue(google_mock_store_requests.call['called'])
        self.assertEqual(google_mock_store_requests.call['count'], 1)
        request = google_mock_store_requests.call['requests'][0]
        self.assertEqual(request.body, 'query=foo')

