### PR TITLE
Include tests and useful/related test files in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include README.md LICENSE
+include tests.py .travis.yml


### PR DESCRIPTION
This is useful for downstream users, including OS packagers to QA/test if the package works correctly without requiring fetching the sources from the repository.

Identified by: [FreeBSD Ports Bug 242694](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=242694)

Closes: #55 