### PR TITLE
Enable testing on Python 3.7 and 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
     - 3.5
     - 3.6
     - 3.7
+    - 3.8
 install:
     - "pip install requests"
 script: nosetests

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
     - 3.4
     - 3.5
     - 3.6
+    - 3.7
 install:
     - "pip install requests"
 script: nosetests


### PR DESCRIPTION
httmock tests pass on Python 3.7 and 3.8. 

Enable testing on these versions in Travis CI accordingly

Python 3.7: Ran 30 tests in 0.269s - OK
Python 3.8: Ran 30 tests in 0.135s - OK