### PR TITLE
Add architecture ppc64le to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+os: linux
+arch:
+ - amd64
+ - ppc64le
 language: python
 python:
     - 2.7
@@ -7,6 +11,10 @@ python:
     - 3.6
     - 3.7
     - 3.8
+jobs: 
+  exclude:
+    - arch: ppc64le
+      python: pypy
 install:
     - "pip install requests"
 script: nosetests


### PR DESCRIPTION
Thank you for the code.
Add support for architecture ppc64le. 
Exclude pypy for ppc64le as it is not available. 
This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3
