### PR TITLE
Add res.raw.version for responses

### DIFF
--- a/httmock.py
+++ b/httmock.py
@@ -14,10 +14,7 @@ except ImportError:
 if sys.version_info >= (3, 0, 0):
     from io import BytesIO
 else:
-    try:
-        from cStringIO import StringIO as BytesIO
-    except ImportError:
-        from StringIO import StringIO as BytesIO
+    from StringIO import StringIO as BytesIO
 
 
 binary_type = bytes
@@ -39,7 +36,7 @@ class Headers(object):
 
 
 def response(status_code=200, content='', headers=None, reason=None, elapsed=0,
-             request=None, stream=False):
+             request=None, stream=False, http_vsn=11):
     res = requests.Response()
     res.status_code = status_code
     if isinstance(content, (dict, list)):
@@ -64,6 +61,7 @@ def response(status_code=200, content='', headers=None, reason=None, elapsed=0,
         res.raw = BytesIO(content)
     else:
         res.raw = BytesIO(b'')
+    res.raw.version = http_vsn
 
     # normally this closes the underlying connection,
     #  but we have nothing to free.
@@ -231,7 +229,8 @@ class HTTMock(object):
                             res.get('reason'),
                             res.get('elapsed', 0),
                             request,
-                            stream=kwargs.get('stream', False))
+                            stream=kwargs.get('stream', False),
+                            http_vsn=res.get('http_vsn', 11))
         elif isinstance(res, (text_type, binary_type)):
             return response(content=res, stream=kwargs.get('stream', False))
         elif res is None:

--- a/tests.py
+++ b/tests.py
@@ -66,7 +66,8 @@ def any_mock(url, request):
 def dict_any_mock(url, request):
     return {
         'content': 'Hello from %s' % (url.netloc,),
-        'status_code': 200
+        'status_code': 200,
+        'http_vsn': 10,
     }
 
 
@@ -136,6 +137,13 @@ class MockTest(unittest.TestCase):
         self.assertEqual(r.text, u'Motörhead')
         self.assertEqual(r.content, r.text.encode('utf-8'))
 
+    def test_has_raw_version(self):
+        with HTTMock(any_mock):
+            r = requests.get('http://example.com')
+        self.assertEqual(r.raw.version, 11)
+        with HTTMock(dict_any_mock):
+            r = requests.get('http://example.com')
+        self.assertEqual(r.raw.version, 10)
 
 class DecoratorTest(unittest.TestCase):
 
@@ -241,6 +249,11 @@ class ResponseTest(unittest.TestCase):
     def test_response_headers(self):
         r = response(200, None, {'Content-Type': 'application/json'})
         self.assertEqual(r.headers['content-type'], 'application/json')
+
+    def test_response_raw_version(self):
+        r = response(200, None, {'Content-Type': 'application/json'},
+                     http_vsn=10)
+        self.assertEqual(r.raw.version, 10)
 
     def test_response_cookies(self):
         @all_requests


### PR DESCRIPTION
`Response` objects have a `HTTPResponse` object in their `raw` attribute, and that has a `version` attribute that contains the HTTP version of the connection. HTTMock is currently not mocking that attribute, and that makes some other libraries fail when they expect that to be available, like `opentelemetry-instrumentor-requests`.

```
Python 3.6.9 (default, Apr 15 2020, 09:31:57) 
[GCC 4.2.1 Compatible Apple LLVM 11.0.0 (clang-1100.0.33.17)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import requests
>>> r = requests.get('http://google.com')
>>> r.raw.version
11
>>> 
```

It's necessary that we stop using `cStringIO` because it's not possible to set attributes on objects generated from that module.