### PR TITLE
Add tox.ini to make local testing easy

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,13 @@
+# Tox (https://tox.readthedocs.io) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported Python versions. To use it,
+# "python -m pip install tox" and then run "tox" from this directory.
+
+[tox]
+envlist = py{27, 34, 35, 36, 37, 38, 39, 310, 311, py2, py3}
+
+[testenv]
+deps =
+    pytest
+    requests
+commands = {envpython} -b -m pytest -W always tests.py {posargs}


### PR DESCRIPTION
To use:

```sh
python -m pip install tox
tox               # to test all versions
tox -s            # --skip-missing-interpreters, if you don't have a version installed
tox -e py310      # to test a single version
tox -e py27,py310 # to test more than one
tox -p auto       # run in parallel
```

For example:

![image](https://user-images.githubusercontent.com/1324225/148771427-ba74d990-519e-4299-9cb7-807bb0ce79b1.png)
