### PR TITLE
Test with GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,34 @@
+name: Test
+
+on: [push, pull_request, workflow_dispatch]
+
+env:
+  FORCE_COLOR: 1
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["pypy-2.7", "pypy-3.8", "2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10"]
+        os: [windows-latest, macos-latest, ubuntu-latest]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: ".github/workflows/test.yml"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install -U pip
+          python -m pip install -U tox
+
+      - name: Tox tests
+        run: |
+          tox -e py

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,13 @@
+# Tox (https://tox.readthedocs.io) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported Python versions. To use it,
+# "python -m pip install tox" and then run "tox" from this directory.
+
+[tox]
+envlist = py{27, 34, 35, 36, 37, 38, 39, 310, 311, py2, py3}
+
+[testenv]
+deps =
+    pytest
+    requests
+commands = {envpython} -b -m pytest -W always tests.py {posargs}


### PR DESCRIPTION
Includes #64.

Travis CI has a new pricing model making it harder to test open source projects, and it's also stopped running.

This PR add testing on GitHub Actions. 

# Pros

* 20 parallel jobs, not 5 like Travis
* Can test on Windows and macOS, not just Ubuntu
* Very flexible, lots of extra actions (aka add-ons) available
* The new popular CI for Python projects
* No confusing pricing model

# Cons

* Does not have ppc64le architecture
* Does not have EOL Python 3.4 (I would recommend dropping EOL 2.7 and 3.4-3.6)

If ppc64le isn't important, I'd recommend deleting `.travis.yml` outright.

# Demo

https://github.com/hugovk/httmock/actions/runs/1677534178

