### PR TITLE
Support content encodings other than utf-8

### DIFF
--- a/httmock.py
+++ b/httmock.py
@@ -39,6 +39,7 @@ def response(status_code=200, content='', headers=None, reason=None, elapsed=0,
              request=None, stream=False, http_vsn=11):
     res = requests.Response()
     res.status_code = status_code
+    res.headers = structures.CaseInsensitiveDict(headers or {})
     res.encoding = utils.get_encoding_from_headers(res.headers)
     if isinstance(content, (dict, list)):
         content = json.dumps(content).encode(res.encoding or 'utf-8')
@@ -46,7 +47,6 @@ def response(status_code=200, content='', headers=None, reason=None, elapsed=0,
         content = content.encode(res.encoding or 'utf-8')
     res._content = content
     res._content_consumed = content
-    res.headers = structures.CaseInsensitiveDict(headers or {})
     res.reason = reason
     res.elapsed = datetime.timedelta(elapsed)
     res.request = request

--- a/httmock.py
+++ b/httmock.py
@@ -39,14 +39,14 @@ def response(status_code=200, content='', headers=None, reason=None, elapsed=0,
              request=None, stream=False, http_vsn=11):
     res = requests.Response()
     res.status_code = status_code
+    res.encoding = utils.get_encoding_from_headers(res.headers)
     if isinstance(content, (dict, list)):
-        content = json.dumps(content).encode('utf-8')
+        content = json.dumps(content).encode(res.encoding or 'utf-8')
     if isinstance(content, text_type):
-        content = content.encode('utf-8')
+        content = content.encode(res.encoding or 'utf-8')
     res._content = content
     res._content_consumed = content
     res.headers = structures.CaseInsensitiveDict(headers or {})
-    res.encoding = utils.get_encoding_from_headers(res.headers)
     res.reason = reason
     res.elapsed = datetime.timedelta(elapsed)
     res.request = request

--- a/tests.py
+++ b/tests.py
@@ -58,6 +58,15 @@ def charset_utf8(url, request):
         }
     }
 
+@all_requests
+def charset_ISO88591(url, request):
+    return {
+        'content': u'<div>google</div>'.encode('ISO-8859-1'),
+        'status_code': 200,
+        'headers': {
+            'Content-Type': 'text/html; charset=ISO-8859-1'
+        }
+    }
 
 def any_mock(url, request):
     return 'Hello from %s' % (url.netloc,)
@@ -136,6 +145,13 @@ class MockTest(unittest.TestCase):
         self.assertEqual(r.encoding, 'utf-8')
         self.assertEqual(r.text, u'Motörhead')
         self.assertEqual(r.content, r.text.encode('utf-8'))
+
+    def test_encoding_from_non_utf8_contenttype(self):
+        with HTTMock(charset_ISO88591):
+            r = requests.get('http://google.com/')
+        self.assertEqual(r.encoding, 'ISO-8859-1')
+        self.assertEqual(r.text, u'<div>google</div>')
+        self.assertEqual(r.content, r.text.encode('ISO-8859-1'))
 
     def test_has_raw_version(self):
         with HTTMock(any_mock):


### PR DESCRIPTION
This MR fixes #67.

Changes:

- Use encoding from headers to encode the content attributes
- Add a regression test